### PR TITLE
탈퇴 후 화면 전환

### DIFF
--- a/Projects/FITRUN/Sources/AppCoordinator.swift
+++ b/Projects/FITRUN/Sources/AppCoordinator.swift
@@ -108,6 +108,8 @@ extension AppCoordinatorImpl: CoordinatorFinishDelegate {
       showMainTab()
     case .onboarding:
       showMainTab()
+    case .mainTabBar:
+      showWalkthrough()
     default:
       break
     }

--- a/Projects/Presentation/Presentation/Sources/MainTabBar/Home/View/WeeklyRunningGoalCardView.swift
+++ b/Projects/Presentation/Presentation/Sources/MainTabBar/Home/View/WeeklyRunningGoalCardView.swift
@@ -31,7 +31,9 @@ public class WeeklyRunningGoalCardView: BaseView {
   }
 
   let editButton = UIButton(type: .system).then {
-    $0.setImage(UIImage(systemName: "pencil"), for: .normal)
+    let image = UIImage(named: "EditPencil", in: .module, with: nil)?
+      .resized(to: CGSize(width: 24, height: 24))
+    $0.setImage(image, for: .normal)
     $0.tintColor = .gray
   }
 

--- a/Projects/Presentation/Presentation/Sources/MainTabBar/MainTabBarCoordinator.swift
+++ b/Projects/Presentation/Presentation/Sources/MainTabBar/MainTabBarCoordinator.swift
@@ -119,10 +119,6 @@ public class MainTabBarCoordinatorImpl: NSObject, MainTabBarCoordinator {
   func currentPage() -> TabBarPage? {
     TabBarPage(rawValue: tabBarController.selectedIndex)
   }
-
-  func removeChildCoordinator(_ coordinator: Coordinator) {
-    childCoordinators = childCoordinators.filter { $0 !== coordinator }
-  }
 }
 
 // MARK: - UITabBarControllerDelegate
@@ -139,6 +135,11 @@ extension MainTabBarCoordinatorImpl: UITabBarControllerDelegate {
 
 extension MainTabBarCoordinatorImpl: CoordinatorFinishDelegate {
   public func coordinatorDidFinish(childCoordinator: Coordinator) {
-    removeChildCoordinator(childCoordinator)
+    self.childCoordinators = childCoordinators.filter({ $0.type != childCoordinator.type })
+
+    if childCoordinator.type == .myPage {
+      navigationController.dismiss(animated: false)
+      finishDelegate?.coordinatorDidFinish(childCoordinator: self)
+    }
   }
 }

--- a/Projects/Presentation/Presentation/Sources/MainTabBar/MyPage/DeleteAccount/DeleteAccountViewController.swift
+++ b/Projects/Presentation/Presentation/Sources/MainTabBar/MyPage/DeleteAccount/DeleteAccountViewController.swift
@@ -196,8 +196,7 @@ public final class DeleteAccountViewController: BaseViewController, View {
       .observe(on: MainScheduler.instance)
       .filter { $0 }
       .subscribe(with: self) { owner, accountDeleted in
-        print("reactor.state.map(accountDeleted)")
-        // MARK: - 여기서 런치스크린 이동
+        owner.coordinator?.showWalkthrough()
       }
       .disposed(by: disposeBag)
   }

--- a/Projects/Presentation/Presentation/Sources/MainTabBar/MyPage/MyPageCoordinator.swift
+++ b/Projects/Presentation/Presentation/Sources/MainTabBar/MyPage/MyPageCoordinator.swift
@@ -18,6 +18,7 @@ public protocol MyPageCoordinator: Coordinator {
   func showPaceCountSettingVC()
   func showRunningSetting()
   func showMyNotiSettingVC()
+  func showWalkthrough()
 }
 
 public final class MyPageCoordinatorImpl: MyPageCoordinator {
@@ -92,6 +93,11 @@ public final class MyPageCoordinatorImpl: MyPageCoordinator {
     let vc = resolver.resolve(MyNotiSettingViewController.self)!
     vc.coordinator = self
     navigationController.pushViewController(vc, animated: true)
+  }
+
+  public func showWalkthrough() {
+    self.navigationController.viewControllers.removeAll()
+    self.finish()
   }
 }
 


### PR DESCRIPTION
## 📌 작업 내용 간단 요약
- 탈퇴 후 화면 전환 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 메인 탭바 종료 시 워크스루로 자연스럽게 전환되도록 네비게이션 흐름을 추가했습니다.
  - 계정 삭제 완료 시 워크스루로 이동하도록 동작을 연결했습니다.
- 스타일
  - 홈 화면 주간 달리기 목표 카드의 편집 아이콘을 시스템 아이콘에서 커스텀 에셋으로 변경해 일관된 디자인을 제공합니다.
- 리팩터링
  - 코디네이터 종료 처리와 하위 코디네이터 정리를 개선해 화면 전환 안정성을 높였습니다.
  - 마이페이지 플로우에 워크스루 호출 기능을 추가해 흐름 제어를 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->